### PR TITLE
Remove external adapter dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'griddler', github: 'thoughtbot/griddler'
-gem 'griddler-sendgrid', github: 'thoughtbot/griddler-sendgrid'
 
 gemspec


### PR DESCRIPTION
Griddler no longer requires adapters, so you don't need to have them either.
