### PR TITLE
Mandrill attachments are NOT always Base64 encoded

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -62,7 +62,9 @@ module Griddler
       def create_tempfile(attachment)
         filename = attachment[:name]
         tempfile = Tempfile.new(filename, Dir::tmpdir, encoding: 'ascii-8bit')
-        tempfile.write(Base64.decode64(attachment[:content]))
+        content = attachment[:content]
+        content = Base64.decode64(content) if attachment[:base64]
+        tempfile.write(content)
         tempfile.rewind
         tempfile
       end


### PR DESCRIPTION
According to Mandrill's documentation, the attachments array's contents
are NOT always Base64 encoded:
http://help.mandrill.com/entries/22092308-What-is-the-format-of-inbound-email-webhooks-

In particular, text attachments are not Base64 encoded unless they
contain non-UTF-8 characters. By always trying to Base64 decode the
attachments this adapter was corrupting Mandrill text file attachments.

This PR simply respects the base64 flag that Mandrill sends along with
each attachment to know whether or not to decode the content field.
