### PR TITLE
Handle text and html fields being `null`.

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -18,8 +18,8 @@ module Griddler
             bcc: recipients(:bcc, event),
             from: full_email([ event[:from_email], event[:from_name] ]),
             subject: event[:subject],
-            text: event.fetch(:text, ''),
-            html: event.fetch(:html, ''),
+            text: event[:text] || '',
+            html: event[:html] || '',
             raw_body: event[:raw_msg],
             attachments: attachment_files(event)
           }

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -80,10 +80,40 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     end
   end
 
+  describe 'when the email text part is nil' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:text] = nil
+    end
+
+    it 'sets :text to an empty string' do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      normalized_params.each do |p|
+        expect(p[:text]).to eq ''
+      end
+    end
+  end
+
   describe 'when the email has no html part' do
     before do
       @params = params_hash
       @params.first[:msg].delete(:html)
+    end
+
+    it 'sets :html to an empty string' do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      normalized_params.each do |p|
+        expect(p[:html]).to eq ''
+      end
+    end
+  end
+
+  describe 'when the email html part is nil' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:html] = nil
     end
 
     it 'sets :html to an empty string' do


### PR DESCRIPTION
In some cases, the text and html fields of a `msg` object received from
Mandrill are set to null. In these cases, the text and html parameters are
set to empty strings.
