### PR TITLE
Add support for headers

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -16,6 +16,7 @@ module Griddler
             to: recipients(:to, event),
             cc: recipients(:cc, event),
             bcc: recipients(:bcc, event),
+            headers: event[:headers],
             from: full_email([ event[:from_email], event[:from_name] ]),
             subject: event[:subject],
             text: event[:text] || '',

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -25,6 +25,14 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     end
   end
 
+  describe Griddler::Email do
+    it 'accepts the mandrill headers hash without error' do
+      params = mixed_event_params
+      params_to_send = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect{Griddler::EmailParser.extract_headers(params_to_send.first[:headers])}.to_not raise_error(NoMethodError)
+    end
+  end
+
   it 'passes the received array of files' do
     params = params_with_attachments
 

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -178,7 +178,9 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       msg:
         {
           raw_msg: 'raw',
-          headers: {},
+          headers: {"X-Mailer" => "Airmail (271)",
+                    "Mime-Version" => "1.0",
+                    "Content-Type" => "multipart/alternative; boundary=\"546876a7_66334873_aa8\""},
           text: text_body,
           html: text_html,
           from_email: 'hernan@example.com',
@@ -208,6 +210,9 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
            'Joey <joey@example.mandrillapp.com>'],
       bcc: ['Roger <hidden@example.mandrillapp.com>'],
       from: 'Hernan Example <hernan@example.com>',
+      headers: {"X-Mailer" => "Airmail (271)",
+                "Mime-Version" => "1.0",
+                "Content-Type" => "multipart/alternative; boundary=\"546876a7_66334873_aa8\""},
       subject: 'hello',
       text: %r{Dear bob},
       html: %r{<p>Dear bob</p>},


### PR DESCRIPTION
This adds support for headers. 

This should not be merged until thoughtbot/griddler#185 is merged. If this change is implemented at the moment the Griddler gem will through an error. This is because the Griddler gem will try to pass the headers from a string instead of leave the headers as they are (which is what this change does).