### PR TITLE
Adds the ability to parse From, To:, Cc:, Bcc: from raw headers

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -71,7 +71,7 @@ module Griddler
             name = email_info.strip
             name = nil if name.empty? #name is whatever is left
             full_email([ email, name ])
-          })
+          }) unless emails.blank?
         end
 
         []

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -16,7 +16,7 @@ module Griddler
             to: recipients(:to, event),
             cc: recipients(:cc, event),
             bcc: recipients(:bcc, event),
-            from: full_email([ event[:from_email], event[:from_name] ]),
+            from: from(event),
             subject: event[:subject],
             text: event[:text] || '',
             html: event[:html] || '',
@@ -36,8 +36,44 @@ module Griddler
         }.compact
       end
 
+      def from(event)
+        from_contact = full_email([ event[:from_email], event[:from_name] ])
+        # Attempt to get from contact from raw headers as a last resort
+        from_contact = header_contacts(:from, event).first if from_contact.nil?
+        from_contact
+      end
+
       def recipients(field, event)
-        Array.wrap(event[field]).map { |recipient| full_email(recipient) }
+        rcpts = Array.wrap(event[field]).map { |recipient| full_email(recipient) }
+        # Attempt to get recipients from raw headers as a last resort
+        rcpts = header_contacts(field, event) if rcpts.empty?
+        rcpts
+      end
+
+      def header_contacts(field, event)
+        case field
+        when :from
+          header_prefix = 'From:'
+        when :to
+          header_prefix = 'To:'
+        when :cc
+          header_prefix = 'Cc:'
+        when :bcc
+          header_prefix = 'Bcc:'
+        end
+
+        if event[:raw_msg].present? && matches = event[:raw_msg].match(/\n#{header_prefix}.+\n/i)
+          emails = matches.to_s.gsub!(/\n|#{header_prefix}/i,'')
+
+          return Array.wrap(emails.split(',').map { |email_info|
+            email = email_info.scan(email_regex).first
+            email_info.gsub!(/#{email}|<|>/i, '') #remove the email address
+            name = email_info.strip #name is whatever is left
+            full_email([ email, name ])
+          })
+        end
+
+        []
       end
 
       def full_email(contact_info)
@@ -68,6 +104,11 @@ module Griddler
         tempfile.write(content)
         tempfile.rewind
         tempfile
+      end
+
+      # http://www.regular-expressions.info/email.html
+      def email_regex
+        /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b/i
       end
     end
   end

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -67,8 +67,9 @@ module Griddler
 
           return Array.wrap(emails.split(',').map { |email_info|
             email = email_info.scan(email_regex).first
-            email_info.gsub!(/#{email}|<|>/i, '') #remove the email address
-            name = email_info.strip #name is whatever is left
+            email_info.gsub!(/#{Regexp.escape(email)}|<|>/i, '') #remove the email address
+            name = email_info.strip
+            name = nil if name.empty? #name is whatever is left
             full_email([ email, name ])
           })
         end

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -216,7 +216,7 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
         {
           raw_msg: %Q[Received: from SNT004-OMC2S19.example.com (unknown [10.10.10.10])
 \tby ip-10-10-10-10 (Postfix) with ESMTPS id 229D32C0086
-\tfor <delivery@email.joistapp.com>; Sat, 20 Dec 2014 01:29:03 +0000 (UTC)
+\tfor <delivery@example.com>; Sat, 20 Dec 2014 01:29:03 +0000 (UTC)
 Received: from SNT004-MC4F26.example.com ([10.10.10.10]) by SNT004-OMC2S19.example.com over TLS secured channel with Example SMTPSVC(7.5.7601.22751);
 \t Fri, 19 Dec 2014 17:29:01 -0800
 To: The Token <token@reply.example.com>
@@ -266,7 +266,7 @@ X-OriginalArrivalTime: 20 Dec 2014 01:29:01.0846 (UTC) FILETIME=[55C18360:01D01B
       html: %r{<p>Dear bob</p>},
       raw_body: %Q[Received: from SNT004-OMC2S19.example.com (unknown [10.10.10.10])
 \tby ip-10-10-10-10 (Postfix) with ESMTPS id 229D32C0086
-\tfor <delivery@email.joistapp.com>; Sat, 20 Dec 2014 01:29:03 +0000 (UTC)
+\tfor <delivery@example.com>; Sat, 20 Dec 2014 01:29:03 +0000 (UTC)
 Received: from SNT004-MC4F26.example.com ([10.10.10.10]) by SNT004-OMC2S19.example.com over TLS secured channel with Example SMTPSVC(7.5.7601.22751);
 \t Fri, 19 Dec 2014 17:29:01 -0800
 To: The Token <token@reply.example.com>

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -129,6 +129,7 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     before do
       @params = params_hash
       @params.first[:msg][:cc] = nil
+      @params.first[:msg][:raw_msg] = nil
     end
 
     it 'should return an empty cc array' do
@@ -139,6 +140,42 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       end
     end
   end
+
+  describe 'when the from info is only in the headers' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:from_email] = nil
+      @params.first[:msg][:from_name] = nil
+    end
+
+    it 'should return from info' do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      normalized_params.each do |p|
+        expect(p[:from]).to eq params_hash_normalized[:from]
+      end
+    end
+  end
+
+  describe 'when the recipients info is only in the headers' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:to] = nil
+      @params.first[:msg][:cc] = nil
+      @params.first[:msg][:bcc] = nil
+    end
+
+    it 'should return recipients info' do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      normalized_params.each do |p|
+        expect(p[:to]).to eq params_hash_normalized[:to]
+        expect(p[:cc]).to eq params_hash_normalized[:cc]
+        expect(p[:bcc]).to eq params_hash_normalized[:bcc]
+      end
+    end
+  end
+
 
   def default_params(params = params_hash)
     mandrill_events (params * 2).to_json
@@ -177,7 +214,23 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       ts: 1364601140,
       msg:
         {
-          raw_msg: 'raw',
+          raw_msg: %Q[Received: from SNT004-OMC2S19.example.com (unknown [10.10.10.10])
+\tby ip-10-10-10-10 (Postfix) with ESMTPS id 229D32C0086
+\tfor <delivery@email.joistapp.com>; Sat, 20 Dec 2014 01:29:03 +0000 (UTC)
+Received: from SNT004-MC4F26.example.com ([10.10.10.10]) by SNT004-OMC2S19.example.com over TLS secured channel with Example SMTPSVC(7.5.7601.22751);
+\t Fri, 19 Dec 2014 17:29:01 -0800
+To: The Token <token@reply.example.com>
+Cc: Emily <emily@example.mandrillapp.com>, Joey <joey@example.mandrillapp.com>
+Bcc: Roger <hidden@example.mandrillapp.com>
+Date: Fri, 19 Dec 2014 17:29:01 -0800
+Message-ID: <SNT004-MC4F26A05458643DDEA2F096C0CF680@phx.gbl>
+X-HM-Routing-Path:6SVjR9/XbxWrMmtiP1ZOER7LJ52F3qioXOfeqL5tnZVoOQ+Tnq8zDVZBtfs8e7oWVzErIgTVzQyg5uZQ+42Fbk+E2iAHdF1+A0tDg5+K+ocImVE+w3xCrLgFwxSkXSnjHjMv6fpaVXmYHVa1Zyay6yl0SV8i4O4lii7rfMLSxOA=
+Content-Type: text/html; charset=\"iso-8859-8-i\"
+From: Hernan Example <hernan@example.com>
+Subject: hello
+Content-Transfer-Encoding: base64
+MIME-Version: 1.0
+X-OriginalArrivalTime: 20 Dec 2014 01:29:01.0846 (UTC) FILETIME=[55C18360:01D01BF4]],
           headers: {},
           text: text_body,
           html: text_html,
@@ -211,7 +264,23 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       subject: 'hello',
       text: %r{Dear bob},
       html: %r{<p>Dear bob</p>},
-      raw_body: %r{raw}
+      raw_body: %Q[Received: from SNT004-OMC2S19.example.com (unknown [10.10.10.10])
+\tby ip-10-10-10-10 (Postfix) with ESMTPS id 229D32C0086
+\tfor <delivery@email.joistapp.com>; Sat, 20 Dec 2014 01:29:03 +0000 (UTC)
+Received: from SNT004-MC4F26.example.com ([10.10.10.10]) by SNT004-OMC2S19.example.com over TLS secured channel with Example SMTPSVC(7.5.7601.22751);
+\t Fri, 19 Dec 2014 17:29:01 -0800
+To: The Token <token@reply.example.com>
+Cc: Emily <emily@example.mandrillapp.com>, Joey <joey@example.mandrillapp.com>
+Bcc: Roger <hidden@example.mandrillapp.com>
+Date: Fri, 19 Dec 2014 17:29:01 -0800
+Message-ID: <SNT004-MC4F26A05458643DDEA2F096C0CF680@phx.gbl>
+X-HM-Routing-Path:6SVjR9/XbxWrMmtiP1ZOER7LJ52F3qioXOfeqL5tnZVoOQ+Tnq8zDVZBtfs8e7oWVzErIgTVzQyg5uZQ+42Fbk+E2iAHdF1+A0tDg5+K+ocImVE+w3xCrLgFwxSkXSnjHjMv6fpaVXmYHVa1Zyay6yl0SV8i4O4lii7rfMLSxOA=
+Content-Type: text/html; charset=\"iso-8859-8-i\"
+From: Hernan Example <hernan@example.com>
+Subject: hello
+Content-Transfer-Encoding: base64
+MIME-Version: 1.0
+X-OriginalArrivalTime: 20 Dec 2014 01:29:01.0846 (UTC) FILETIME=[55C18360:01D01BF4]]
     }
   end
 


### PR DESCRIPTION
Recently we received a webhook from Mandrill that did not contain info in the usual from fields, but we noticed that this info was readily available in the email headers. This PR adds the ability of the adapter to consider the header information when parsing From, To, Cc, Bcc fields.