### PR TITLE
Add support for headers (v2)

### DIFF
--- a/griddler-mandrill.gemspec
+++ b/griddler-mandrill.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'griddler'
+  spec.add_dependency 'griddler', '>= 1.2.0'
 
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rake'

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -16,6 +16,7 @@ module Griddler
             to: recipients(:to, event),
             cc: recipients(:cc, event),
             bcc: recipients(:bcc, event),
+            headers: event[:headers],
             from: full_email([ event[:from_email], event[:from_name] ]),
             subject: event[:subject],
             text: event[:text] || '',

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -29,7 +29,8 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     it 'accepts the mandrill headers hash without error' do
       params = mixed_event_params
       params_to_send = Griddler::Mandrill::Adapter.normalize_params(params)
-      expect{Griddler::EmailParser.extract_headers(params_to_send.first[:headers])}.to_not raise_error(NoMethodError)
+      headers = Griddler::EmailParser.extract_headers(params_to_send.first[:headers])
+      expect{headers}.not_to raise_error
     end
   end
 
@@ -321,7 +322,6 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       {
         name: '=?UTF-8?B?0JrQvtC/0LjRjyB0ZW5kZXJfMTJfcm9zdGEueGxz?=',
         content: content,
-        type: 'image/jpeg',
         type: 'text/plain',
         base64: false
       }

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -25,6 +25,14 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     end
   end
 
+  describe Griddler::Email do
+    it 'accepts the mandrill headers hash without error' do
+      params = mixed_event_params
+      params_to_send = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect{Griddler::EmailParser.extract_headers(params_to_send.first[:headers])}.to_not raise_error(NoMethodError)
+    end
+  end
+
   it 'passes the received array of files' do
     params = params_with_attachments
 

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -178,7 +178,9 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       msg:
         {
           raw_msg: 'raw',
-          headers: {},
+          headers: {"X-Mailer" => "Airmail (271)",
+                    "Mime-Version" => "1.0",
+                    "Content-Type" => "multipart/alternative; boundary=\"546876a7_66334873_aa8\""},
           text: text_body,
           html: text_html,
           from_email: 'hernan@example.com',
@@ -208,6 +210,9 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
            'Joey <joey@example.mandrillapp.com>'],
       bcc: ['Roger <hidden@example.mandrillapp.com>'],
       from: 'Hernan Example <hernan@example.com>',
+      headers: {"X-Mailer" => "Airmail (271)",
+                "Mime-Version" => "1.0",
+                "Content-Type" => "multipart/alternative; boundary=\"546876a7_66334873_aa8\""},
       subject: 'hello',
       text: %r{Dear bob},
       html: %r{<p>Dear bob</p>},


### PR DESCRIPTION
This is a continuation of @matthewbarram's #12. This are his three commits for supporting hash headers in the `griddler` gem + a few minor fixes by me.