### PR TITLE
Check for SPF results before sending over emails

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -11,7 +11,9 @@ module Griddler
       end
 
       def normalize_params
-        events.map do |event|
+        events.select do |event|
+          event[:spf].present? && (event[:spf][:result] == 'pass' || event[:spf][:result] == 'neutral')
+        end.map do |event|
           {
             to: recipients(:to, event),
             cc: recipients(:cc, event),

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -104,6 +104,45 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     end
   end
 
+  describe 'when the spf record is softfail' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'softfail', detail: 'domain owner discourages use of this host' }
+    end
+
+    it "doesn't include emails that have failed the SPF test" do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params).to be_empty
+    end
+  end
+
+  describe 'when the spf record is fail' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'fail', detail: 'sender SPF fail' }
+    end
+
+    it "doesn't include emails that have failed the SPF test" do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params).to be_empty
+    end
+  end
+
+  describe 'when the spf record is neutral' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'neutral', detail: 'sender SPF neutral' }
+    end
+
+    it "does include emails that have the SPF result as 'neutral'" do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params.size).to eql 2
+    end
+  end
+
   describe 'when the email has no html part' do
     before do
       @params = params_hash


### PR DESCRIPTION
Protects against SPF spoofing