### PR TITLE
Inline images

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -60,12 +60,17 @@ module Griddler
       end
 
       def attachment_files(event)
-        attachments = event[:attachments] || Array.new
-        attachments.map do |key, attachment|
+        files(event, :attachments) + files(event, :images)
+      end
+
+      def files(event, key)
+        files = event[key] || Hash.new
+
+        files.map do |key, file|
           ActionDispatch::Http::UploadedFile.new({
-            filename: attachment[:name],
-            type: attachment[:type],
-            tempfile: create_tempfile(attachment)
+            filename: file[:name],
+            type: file[:type],
+            tempfile: create_tempfile(file)
           })
         end
       end

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -74,6 +74,20 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     expect{adapter.normalize_params}.to_not raise_error
   end
 
+  it 'works with inline images' do
+    params = params_with_inline_images
+
+    normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+
+    first, second = *normalized_params[0][:attachments]
+
+    expect(first.original_filename).to eq('ii_111ecfcf901e123c')
+    expect(first.size).to eq(upload_6_params[:length])
+
+    expect(second.original_filename).to eq('ii_151ecfcf901e828c')
+    expect(second.size).to eq(upload_7_params[:length])
+  end
+
   describe 'when the email has no text part' do
     before do
       @params = params_hash
@@ -315,6 +329,15 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     mandrill_events params.to_json
   end
 
+  def params_with_inline_images
+    params = params_hash
+    params[0][:msg][:images] = {
+      'ii_151ecfcf901e828c' => upload_6_params,
+      'ii_111ecfcf901e123c' => upload_7_params
+    }
+    mandrill_events params.to_json
+  end
+
   def text_body
     <<-EOS.strip_heredoc.strip
       Dear bob
@@ -400,4 +423,33 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
       }
     end
   end
+
+  def upload_6_params
+    @upload_6_params ||= begin
+      file = upload_1
+      size = file.size
+      {
+        name: 'ii_111ecfcf901e123c',
+        content: Base64.encode64(file.read),
+        type: 'image/jpeg',
+        length: size,
+        base64: true
+      }
+    end
+  end
+
+  def upload_7_params
+    @upload_7_params ||= begin
+      file = upload_2
+      size = file.size
+      {
+        name: 'ii_151ecfcf901e828c',
+        content: Base64.encode64(file.read),
+        type: 'image/jpeg',
+        length: size,
+        base64: true
+      }
+    end
+  end
+
 end


### PR DESCRIPTION
Griddler-mandrill doesn't support inline images comming from Mandrill.

Here is the issue about that #15 

I implemented this functionality based on official documentation for Mandrill - https://mandrill.zendesk.com/hc/en-us/articles/205583207-What-is-the-format-of-inbound-email-webhooks-

Functionality is the same as for attachments.