### PR TITLE
Add missing base64 field for images

### DIFF
--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -59,17 +59,7 @@ module Griddler
         end
       end
 
-      def add_base64_field(event, key, default_value)
-        if event[key]
-          event[key].each_value do |value| 
-            value[:base64] ||= default_value
-          end
-        end
-      end
-
       def attachment_files(event)
-        add_base64_field(event, :images, true)
-
         files(event, :attachments) + files(event, :images)
       end
 
@@ -77,6 +67,8 @@ module Griddler
         files = event[key] || Hash.new
 
         files.map do |key, file|
+          file[:base64] = true if !file.has_key?(:base64)
+
           ActionDispatch::Http::UploadedFile.new({
             filename: file[:name],
             type: file[:type],

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -62,7 +62,7 @@ module Griddler
       def add_base64_field(event, key, default_value)
         if event[key]
           event[key].each_value do |value| 
-            value[:base64] = default_value if !value.has_key?(:base64)
+            value[:base64] ||= default_value
           end
         end
       end

--- a/lib/griddler/mandrill/adapter.rb
+++ b/lib/griddler/mandrill/adapter.rb
@@ -59,7 +59,17 @@ module Griddler
         end
       end
 
+      def add_base64_field(event, key, default_value)
+        if event[key]
+          event[key].each_value do |value| 
+            value[:base64] = default_value if !value.has_key?(:base64)
+          end
+        end
+      end
+
       def attachment_files(event)
+        add_base64_field(event, :images, true)
+
         files(event, :attachments) + files(event, :images)
       end
 

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -432,8 +432,7 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
         name: 'ii_111ecfcf901e123c',
         content: Base64.encode64(file.read),
         type: 'image/jpeg',
-        length: size,
-        base64: true
+        length: size
       }
     end
   end
@@ -446,8 +445,7 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
         name: 'ii_151ecfcf901e828c',
         content: Base64.encode64(file.read),
         type: 'image/jpeg',
-        length: size,
-        base64: true
+        length: size
       }
     end
   end


### PR DESCRIPTION
Mandrill doesn't provide base64 field for images (inline images)

@wingrunr21 You were right.