### PR TITLE
Allow processing when domains do not have SPF configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Once you have correctly configured Mandrill, you can go ahead and delete this co
 
 [Adding Routes]: http://help.mandrill.com/entries/21699367-Inbound-Email-Processing-Overview
 
+#### Allowing domains without SPF configured
+Sometimes, due to circumstances outside our control, a domain may not have SPF set up. In those cases, you can set the adapter to pass results to your email processor.
+
+```
+Griddler::Mandrill::Adapter.allow_spf_none = true
+```
+
+
 ## Credits
 
 Griddler::Mandrill was extracted from Griddler by [Stafford Brunk](https://github.com/wingrunr21).

--- a/spec/griddler/mandrill/adapter_spec.rb
+++ b/spec/griddler/mandrill/adapter_spec.rb
@@ -118,6 +118,33 @@ describe Griddler::Mandrill::Adapter, '.normalize_params' do
     end
   end
 
+  describe 'when the spf record is none' do
+    before do
+      @params = params_hash
+      @params.first[:msg][:spf] = { result: 'none', detail: '' }
+    end
+
+    it 'does not include the emails without spf results by default' do
+      params = default_params(@params)
+      normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+      expect(normalized_params).to be_empty
+    end
+
+    context 'when the adapter is configured to allow none' do
+      before do
+        Griddler::Mandrill::Adapter.allow_spf_none = true
+      end
+      after do
+        Griddler::Mandrill::Adapter.allow_spf_none = false
+      end
+      it 'includes the message' do
+        params = default_params(@params)
+        normalized_params = Griddler::Mandrill::Adapter.normalize_params(params)
+        expect(normalized_params).not_to be_empty
+      end
+    end
+  end
+
   describe 'when the spf record is softfail' do
     before do
       @params = params_hash


### PR DESCRIPTION
See: https://github.com/wingrunr21/griddler-mandrill/issues/23

At this time, there does not appear to be a mechanism for logging
failures; but that could be added later.